### PR TITLE
refactor: remove unnecessary os.Exit(0) since log.Fatal exits

### DIFF
--- a/cmd/port-service/main.go
+++ b/cmd/port-service/main.go
@@ -20,7 +20,6 @@ func main() {
 	if err := run(); err != nil {
 		log.Fatal(err)
 	}
-	os.Exit(0)
 }
 
 func run() error {


### PR DESCRIPTION
Hi Eugene 
please accept this as a simple and minor improvement :)
I know you never done such a thing in your other repos so why not having this small fix here as well, please?

Thanks in advance!

PS. I have only PHP contributions so far and hope you will make this as my first Golang opensource contrib accepted! 

:D